### PR TITLE
don't allow both swoole and openswoole

### DIFF
--- a/ext-src/php_swoole.cc
+++ b/ext-src/php_swoole.cc
@@ -220,6 +220,7 @@ const zend_function_entry swoole_functions[] = {
 };
 
 static const zend_module_dep swoole_deps[] = {
+    ZEND_MOD_CONFLICTS("swoole")
 #ifdef SW_USE_JSON
     ZEND_MOD_REQUIRED("json")
 #endif


### PR DESCRIPTION
Both extensions provide same functions.

Trying to load both results in tons of errors

Ex:

```
PHP Warning:  Function registration failed - duplicate name - swoole_version in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_cpu_num in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_last_error in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_async_dns_lookup_coro in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_async_set in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_coroutine_create in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_coroutine_defer in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_coroutine_socketpair in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_test_kernel_coroutine in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_client_select in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_select in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_set_process_name in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_get_local_ip in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_get_local_mac in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_strerror in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_errno in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_clear_error in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_error_log in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_hashcode in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_mime_type_add in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_mime_type_set in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_mime_type_delete in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_mime_type_get in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_get_mime_type in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_mime_type_exists in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_mime_type_list in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_clear_dns_cache in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_substr_unserialize in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_substr_json_decode in Unknown on line 0
PHP Warning:  Function registration failed - duplicate name - swoole_internal_call_user_shutdown_begin in Unknown on line 0

```