### PR TITLE
Fix: server->getWorkerPid did not return the correct worker pid when being called from another worker context

### DIFF
--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -3693,18 +3693,15 @@ static PHP_METHOD(swoole_server, getWorkerStatus) {
 
 static PHP_METHOD(swoole_server, getWorkerPid) {
     Server *serv = php_swoole_server_get_and_check_server(ZEND_THIS);
-    if (!serv->is_worker() && !serv->is_task_worker()) {
-        zend_long worker_id = -1;
-        if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &worker_id) == FAILURE) {
-            RETURN_FALSE;
-        }
-        if (worker_id < 0) {
-            RETURN_FALSE;
-        }
-        RETURN_LONG(serv->get_worker(worker_id)->pid);
-    } else {
-        RETURN_LONG(SwooleG.pid);
+    zend_long worker_id = -1;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &worker_id) == FAILURE) {
+        RETURN_FALSE;
     }
+    Worker *worker = worker_id < 0 ? SwooleWG.worker : serv->get_worker(worker_id);
+    if (!worker) {
+        RETURN_FALSE;
+    }
+    RETURN_LONG(worker->pid);
 }
 
 static PHP_METHOD(swoole_server, getManagerPid) {

--- a/tests/swoole_server/object/getWorkerPidFromAnotherWorker.phpt
+++ b/tests/swoole_server/object/getWorkerPidFromAnotherWorker.phpt
@@ -1,0 +1,45 @@
+--TEST--
+swoole_server/object: getWorkerPidFromAnotherWorker()
+--SKIPIF--
+<?php
+//require __DIR__ . '/../../include/skipif.inc';
+?>
+--FILE--
+<?php declare(strict_types = 1);
+require __DIR__ . '/../../include/bootstrap.php';
+
+$pm = new SwooleTest\ProcessManager;
+
+$pm->parentFunc = function ($pid) use ($pm) {
+    go(function () use ($pm) {
+        $json = json_decode(httpGetBody("http://127.0.0.1:{$pm->getFreePort()}/"));
+        Assert::assert($json->result);
+        $pm->kill();
+    });
+    Swoole\Event::wait();
+    $pm->kill();
+};
+
+$pm->childFunc = function () use ($pm) {
+    $serv = new Swoole\Http\Server('127.0.0.1', $pm->getFreePort(), SWOOLE_PROCESS);
+    $serv->set(array(
+        'log_level' => SWOOLE_LOG_ERROR,
+        'worker_num' => 2,
+    ));
+    $serv->on("WorkerStart", function (Swoole\Server $serv, $workerId) use ($pm) {
+        $pm->wakeup();
+        $GLOBALS['pid_worker_'.$workerId] = posix_getpid();
+    });
+    $serv->on('Request', function ($req, $resp) use ($serv) {
+        $resp->end(json_encode(['result' =>
+            $GLOBALS['pid_worker_'.$serv->worker_id] == $serv->getWorkerPid($serv->worker_id) &&
+            $serv->getWorkerPid(0) != $serv->getWorkerPid(1)]
+        ));
+    });
+    $serv->start();
+};
+
+$pm->childFirst();
+$pm->run();
+?>
+--EXPECT--


### PR DESCRIPTION
In my ongoing efforts to backport https://github.com/swoole/swoole-src/pull/4389 I'm now trying to identify and isolate single bug fixes and split new features in multiple PRs.

This one is a bugfix for server->getWorkerPid which always returned the local worker's PID and not the requested worker's pid when being called in worker context