### PR TITLE
Small Refactorings

### DIFF
--- a/core-tests/src/core/base.cpp
+++ b/core-tests/src/core/base.cpp
@@ -38,7 +38,7 @@ TEST(base, dec2hex) {
     sw_free(result);
 }
 
-TEST(base, swoole_hex2dec) {
+TEST(base, hex2dec) {
     size_t n_parsed;
     ASSERT_EQ(swoole_hex2dec("9fff9123", &n_parsed), 2684326179);
     ASSERT_EQ(n_parsed, 8);

--- a/core-tests/src/reactor/base.cpp
+++ b/core-tests/src/reactor/base.cpp
@@ -108,7 +108,7 @@ TEST(reactor, write) {
     ASSERT_EQ(ret, SW_OK);
     ASSERT_NE(SwooleTG.reactor, nullptr);
 
-    swoole_event_set_handler(SW_FD_PIPE | SW_EVENT_READ, [](Reactor *reactor, swEvent *ev) -> int {
+    swoole_event_set_handler(SW_FD_PIPE | SW_EVENT_READ, [](Reactor *reactor, Event *ev) -> int {
         char buffer[16];
 
         ssize_t n = read(ev->fd, buffer, sizeof(buffer));
@@ -136,7 +136,7 @@ static void reactor_test_func(Reactor *reactor) {
     Pipe p(true);
     ASSERT_TRUE(p.ready());
 
-    reactor->set_handler(SW_FD_PIPE | SW_EVENT_READ, [](Reactor *reactor, swEvent *event) -> int {
+    reactor->set_handler(SW_FD_PIPE | SW_EVENT_READ, [](Reactor *reactor, Event *event) -> int {
         char buf[1024];
         size_t l = strlen(pkt);
         size_t n = read(event->fd, buf, sizeof(buf));
@@ -147,7 +147,7 @@ static void reactor_test_func(Reactor *reactor) {
 
         return SW_OK;
     });
-    reactor->set_handler(SW_FD_PIPE | SW_EVENT_WRITE, [](Reactor *reactor, swEvent *event) -> int {
+    reactor->set_handler(SW_FD_PIPE | SW_EVENT_WRITE, [](Reactor *reactor, Event *event) -> int {
         size_t l = strlen(pkt);
         EXPECT_EQ(write(event->fd, pkt, l), l);
         reactor->del(event->socket);

--- a/core-tests/src/server/server.cpp
+++ b/core-tests/src/server/server.cpp
@@ -302,7 +302,7 @@ TEST(server, task_worker) {
     serv.worker_num = 1;
     serv.task_worker_num = 1;
 
-    swListenPort *port = serv.add_port(SW_SOCK_TCP, TEST_HOST, 0);
+    ListenPort *port = serv.add_port(SW_SOCK_TCP, TEST_HOST, 0);
     if (!port) {
         swoole_warning("listen failed, [error=%d]", swoole_get_last_error());
         exit(2);

--- a/core-tests/src/server/server.cpp
+++ b/core-tests/src/server/server.cpp
@@ -298,7 +298,7 @@ TEST(server, dtls) {
 #endif
 
 TEST(server, task_worker) {
-    swServer serv;
+    Server serv;
     serv.worker_num = 1;
     serv.task_worker_num = 1;
 

--- a/ext-src/swoole_coroutine_scheduler.cc
+++ b/ext-src/swoole_coroutine_scheduler.cc
@@ -112,7 +112,7 @@ void php_swoole_coroutine_scheduler_minit(int module_number) {
 static zend_fcall_info_cache exit_condition_fci_cache;
 static bool exit_condition_cleaner;
 
-static bool php_swoole_coroutine_reactor_can_exit(Reactor *reactor, int &event_num) {
+static bool php_swoole_coroutine_reactor_can_exit(Reactor *reactor, size_t &event_num) {
     zval retval;
     int success;
 

--- a/ext-src/swoole_process.cc
+++ b/ext-src/swoole_process.cc
@@ -494,7 +494,7 @@ static PHP_METHOD(swoole_process, signal) {
     SwooleTG.reactor->check_signalfd = true;
     if (!SwooleTG.reactor->isset_exit_condition(Reactor::EXIT_CONDITION_SIGNAL_LISTENER)) {
         SwooleTG.reactor->set_exit_condition(Reactor::EXIT_CONDITION_SIGNAL_LISTENER,
-                                             [](Reactor *reactor, int &event_num) -> bool {
+                                             [](Reactor *reactor, size_t &event_num) -> bool {
                                                  return SwooleTG.signal_listener_num == 0 or !SwooleG.wait_signal;
                                              });
     }

--- a/ext-src/swoole_process_pool.cc
+++ b/ext-src/swoole_process_pool.cc
@@ -295,7 +295,7 @@ static PHP_METHOD(swoole_process_pool, __construct) {
 
     ProcessPool *pool = (ProcessPool *) emalloc(sizeof(*pool));
     *pool = {};
-    if (pool->create(worker_num, (key_t) msgq_key, (swIPC_type) ipc_type) < 0) {
+    if (pool->create(worker_num, (key_t) msgq_key, (swIPCMode) ipc_type) < 0) {
         zend_throw_exception_ex(swoole_exception_ce, errno, "failed to create process pool");
         efree(pool);
         RETURN_FALSE;

--- a/include/swoole.h
+++ b/include/swoole.h
@@ -665,7 +665,7 @@ struct Global {
     network::Socket *aio_default_socket;
     //-----------------------[Hook]--------------------------
     void *hooks[SW_MAX_HOOK_TYPE];
-    std::function<bool(Reactor *reactor, int &event_num)> user_exit_condition;
+    std::function<bool(Reactor *reactor, size_t &event_num)> user_exit_condition;
 
     // bug report message
     std::string bug_report_message = "";

--- a/include/swoole_process_pool.h
+++ b/include/swoole_process_pool.h
@@ -33,7 +33,7 @@ enum swWorker_status {
     SW_WORKER_EXIT = 3,
 };
 
-enum swIPC_type {
+enum swIPCMode {
     SW_IPC_NONE = 0,
     SW_IPC_UNIXSOCK = 1,
     SW_IPC_MSGQUEUE = 2,
@@ -288,7 +288,7 @@ struct ProcessPool {
     int add_worker(Worker *worker);
     int del_worker(Worker *worker);
     void destroy();
-    int create(uint32_t worker_num, key_t msgqueue_key = 0, swIPC_type ipc_mode = SW_IPC_NONE);
+    int create(uint32_t worker_num, key_t msgqueue_key = 0, swIPCMode ipc_mode = SW_IPC_NONE);
     int listen(const char *socket_file, int blacklog);
     int listen(const char *host, int port, int blacklog);
     int schedule();

--- a/include/swoole_reactor.h
+++ b/include/swoole_reactor.h
@@ -168,14 +168,14 @@ class Reactor {
 
     std::function<void(Reactor *)> onBegin;
 
-    int (*write)(Reactor *reactor, network::Socket *socket, const void *buf, size_t n) = nullptr;
-    int (*writev)(Reactor *reactor, network::Socket *socket, const iovec *iov, size_t iovcnt) = nullptr;
+    ssize_t (*write)(Reactor *reactor, network::Socket *socket, const void *buf, size_t n) = nullptr;
+    ssize_t (*writev)(Reactor *reactor, network::Socket *socket, const iovec *iov, size_t iovcnt) = nullptr;
     int (*close)(Reactor *reactor, network::Socket *socket) = nullptr;
 
   private:
     ReactorImpl *impl;
     std::map<int, std::function<void(Reactor *)>> end_callbacks;
-    std::map<int, std::function<bool(Reactor *, int &)>> exit_conditions;
+    std::map<int, std::function<bool(Reactor *, size_t &)>> exit_conditions;
 
   public:
     Reactor(int max_event = SW_REACTOR_MAXEVENTS, Type _type = TYPE_AUTO);
@@ -183,7 +183,7 @@ class Reactor {
     bool if_exit();
     void defer(Callback cb, void *data = nullptr);
     void set_end_callback(enum EndCallback id, const std::function<void(Reactor *)> &fn);
-    void set_exit_condition(enum ExitCondition id, const std::function<bool(Reactor *, int &)> &fn);
+    void set_exit_condition(enum ExitCondition id, const std::function<bool(Reactor *, size_t &)> &fn);
     bool set_handler(int _fdtype, ReactorHandler handler);
     void add_destroy_callback(Callback cb, void *data = nullptr);
     void execute_end_callbacks(bool timedout = false);
@@ -326,8 +326,8 @@ class Reactor {
         return false;
     }
 
-    static int _write(Reactor *reactor, network::Socket *socket, const void *buf, size_t n);
-    static int _writev(Reactor *reactor, network::Socket *socket, const iovec *iov, size_t iovcnt);
+    static ssize_t _write(Reactor *reactor, network::Socket *socket, const void *buf, size_t n);
+    static ssize_t _writev(Reactor *reactor, network::Socket *socket, const iovec *iov, size_t iovcnt);
     static int _close(Reactor *reactor, network::Socket *socket);
     static int _writable_callback(Reactor *reactor, Event *ev);
 

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -1253,8 +1253,8 @@ class Server {
     void init_task_workers();
     void init_port_protocol(ListenPort *port);
     void init_signal_handler();
+    void init_ipc_max_size();
 
-    void set_ipc_max_size();
     void set_max_connection(uint32_t _max_connection);
 
     inline uint32_t get_max_connection() {

--- a/include/swoole_server.h
+++ b/include/swoole_server.h
@@ -304,7 +304,7 @@ struct ListenPort {
     Protocol protocol = {};
     void *ptr = nullptr;
 
-    int (*onRead)(Reactor *reactor, ListenPort *port, swEvent *event) = nullptr;
+    int (*onRead)(Reactor *reactor, ListenPort *port, Event *event) = nullptr;
 
     inline bool is_dgram() {
         return network::Socket::is_dgram(type);

--- a/src/core/timer.cc
+++ b/src/core/timer.cc
@@ -77,7 +77,7 @@ bool Timer::init_reactor(Reactor *reactor) {
     reactor->set_end_callback(Reactor::PRIORITY_TIMER, [this](Reactor *) { select(); });
 
     reactor->set_exit_condition(Reactor::EXIT_CONDITION_TIMER,
-                                [this](Reactor *reactor, int &event_num) -> bool { return count() == 0; });
+                                [this](Reactor *reactor, size_t &event_num) -> bool { return count() == 0; });
 
     reactor->add_destroy_callback([](void *) {
         if (swoole_timer_is_available()) {

--- a/src/coroutine/system.cc
+++ b/src/coroutine/system.cc
@@ -271,7 +271,7 @@ bool System::wait_signal(int signo, double timeout) {
     if (!sw_reactor()->isset_exit_condition(Reactor::EXIT_CONDITION_CO_SIGNAL_LISTENER)) {
         sw_reactor()->set_exit_condition(
             Reactor::EXIT_CONDITION_CO_SIGNAL_LISTENER,
-            [](Reactor *reactor, int &event_num) -> bool { return SwooleTG.co_signal_listener_num == 0; });
+            [](Reactor *reactor, size_t &event_num) -> bool { return SwooleTG.co_signal_listener_num == 0; });
     }
     /* always enable signalfd */
     SwooleG.use_signalfd = SwooleG.enable_signalfd = 1;

--- a/src/os/async_thread.cc
+++ b/src/os/async_thread.cc
@@ -400,7 +400,7 @@ AsyncThreads::AsyncThreads() {
         SwooleTG.async_threads = nullptr;
     });
 
-    sw_reactor()->set_exit_condition(Reactor::EXIT_CONDITION_AIO_TASK, [](Reactor *reactor, int &event_num) -> bool {
+    sw_reactor()->set_exit_condition(Reactor::EXIT_CONDITION_AIO_TASK, [](Reactor *reactor, size_t &event_num) -> bool {
         if (SwooleTG.async_threads && SwooleTG.async_threads->task_num == 0) {
             event_num--;
         }

--- a/src/os/process_pool.cc
+++ b/src/os/process_pool.cc
@@ -66,7 +66,7 @@ void ProcessPool::kill_timeout_worker(Timer *timer, TimerNode *tnode) {
 /**
  * Process manager
  */
-int ProcessPool::create(uint32_t _worker_num, key_t _msgqueue_key, swIPC_type _ipc_mode) {
+int ProcessPool::create(uint32_t _worker_num, key_t _msgqueue_key, swIPCMode _ipc_mode) {
     worker_num = _worker_num;
     /**
      * Shared memory is used here

--- a/src/os/signal.cc
+++ b/src/os/signal.cc
@@ -267,7 +267,7 @@ bool swoole_signalfd_setup(Reactor *reactor) {
     }
     if (!swoole_event_isset_handler(SW_FD_SIGNAL)) {
         swoole_event_set_handler(SW_FD_SIGNAL, swoole_signalfd_event_callback);
-        reactor->set_exit_condition(Reactor::EXIT_CONDITION_SIGNALFD, [](Reactor *reactor, int &event_num) -> bool {
+        reactor->set_exit_condition(Reactor::EXIT_CONDITION_SIGNALFD, [](Reactor *reactor, size_t &event_num) -> bool {
             event_num--;
             return true;
         });

--- a/src/os/wait.cc
+++ b/src/os/wait.cc
@@ -76,7 +76,7 @@ static void signal_init() {
         }
 #endif
 
-        reactor->set_exit_condition(Reactor::EXIT_CONDITION_WAIT_PID, [](Reactor *reactor, int &event_num) -> bool {
+        reactor->set_exit_condition(Reactor::EXIT_CONDITION_WAIT_PID, [](Reactor *reactor, size_t &event_num) -> bool {
             return swoole_coroutine_wait_count() == 0;
         });
 

--- a/src/reactor/epoll.cc
+++ b/src/reactor/epoll.cc
@@ -170,7 +170,7 @@ int ReactorEpoll::set(Socket *socket, int events) {
 }
 
 int ReactorEpoll::wait(struct timeval *timeo) {
-    swEvent event;
+    Event event;
     ReactorHandler handler;
     int i, n, ret;
 

--- a/src/server/master.cc
+++ b/src/server/master.cc
@@ -374,7 +374,7 @@ void Server::store_listen_socket() {
  */
 int Server::create_task_workers() {
     key_t key = 0;
-    swIPC_type ipc_mode;
+    swIPCMode ipc_mode;
 
     if (task_ipc_mode == TASK_IPC_MSGQUEUE || task_ipc_mode == TASK_IPC_PREEMPTIVE) {
         key = message_queue_key;
@@ -1703,7 +1703,7 @@ _find_available_slot:
     return connection;
 }
 
-void Server::set_ipc_max_size() {
+void Server::init_ipc_max_size() {
 #ifdef HAVE_KQUEUE
     ipc_max_size = SW_IPC_MAX_SIZE;
 #else

--- a/src/server/process.cc
+++ b/src/server/process.cc
@@ -105,7 +105,7 @@ bool ProcessFactory::start() {
         server_->store_pipe_fd(server_->workers[i].pipe_object);
     }
 
-    server_->set_ipc_max_size();
+    server_->init_ipc_max_size();
     if (server_->create_pipe_buffers() < 0) {
         return false;
     }

--- a/src/server/reactor_process.cc
+++ b/src/server/reactor_process.cc
@@ -348,7 +348,7 @@ static int ReactorProcess_loop(ProcessPool *pool, Worker *worker) {
     // task workers
     if (serv->task_worker_num > 0) {
         if (serv->task_ipc_mode == Server::TASK_IPC_UNIXSOCK) {
-            for (uint32_t i = 0; i < serv->gs->task_workers.worker_num; i++) {
+            SW_LOOP_N(serv->gs->task_workers.worker_num) {
                 serv->gs->task_workers.workers[i].pipe_master->set_nonblock();
             }
         }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -764,7 +764,7 @@ int Server::start_reactor_threads() {
     // init thread barrier
     pthread_barrier_init(&barrier, nullptr, reactor_num + 1);
 #endif
-    for (i = 0; i < reactor_num; i++) {
+    SW_LOOP_N(reactor_num) {
         thread = &(reactor_threads[i]);
         thread->thread = std::thread(ReactorThread_loop, this, i);
     }

--- a/src/server/reactor_thread.cc
+++ b/src/server/reactor_thread.cc
@@ -826,8 +826,8 @@ static int ReactorThread_init(Server *serv, Reactor *reactor, uint16_t reactor_i
     reactor->max_socket = serv->get_max_connection();
     reactor->close = Server::close_connection;
 
-    reactor->set_exit_condition(Reactor::EXIT_CONDITION_DEFAULT, [thread](Reactor *reactor, int &event_num) -> bool {
-        return event_num == (int) thread->pipe_num;
+    reactor->set_exit_condition(Reactor::EXIT_CONDITION_DEFAULT, [thread](Reactor *reactor, size_t &event_num) -> bool {
+        return event_num == (size_t) thread->pipe_num;
     });
 
     reactor->default_error_handler = ReactorThread_onClose;


### PR DESCRIPTION
Hi,

in this pull request of the day I backported some small refactorings from Swoole.

The biggest change is the use of size_t instead of int.
size_t should be used to represent the size of an object (and not int).

Best regards,

Julian