### PR TITLE
Remove data files

### DIFF
--- a/travis/docker-compose.yml
+++ b/travis/docker-compose.yml
@@ -23,9 +23,6 @@ services:
   mysql:
     container_name: "mysql"
     image: "openswoole/mysql5"
-    volumes:
-      - ./data/mysql:/var/lib/mysql:rw
-      - ./data/run/mysqld:/var/run/mysqld:rw
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: test
@@ -40,9 +37,6 @@ services:
   redis:
     container_name: "redis"
     image: "openswoole/redis"
-    volumes:
-      - ./data/redis:/var/lib/redis:rw
-      - ./data/run/redis:/var/run/redis:rw
     sysctls:
         net.core.somaxconn: 65535
   httpbin:

--- a/travis/route.sh
+++ b/travis/route.sh
@@ -43,21 +43,6 @@ check_docker_dependency(){
     fi
 }
 
-prepare_data_files(){
-    cd ${__DIR__} && \
-    remove_data_files && \
-    mkdir -p \
-    data \
-    data/run \
-    data/mysql data/run/mysqld \
-    data/redis data/run/redis && \
-    chmod -R 777 data
-    if [ $? -ne 0 ]; then
-        echo "\n❌ Prepare data files failed!"
-        exit 1
-    fi
-}
-
 remove_data_files(){
     cd ${__DIR__} && \
     rm -rf ../travis/data
@@ -95,9 +80,6 @@ remove_tests_resources(){
 }
 
 check_docker_dependency
-
-echo "\n📖 Prepare for files...\n"
-prepare_data_files
 
 echo "📦 Start docker containers...\n"
 start_docker_containers # && trap "remove_tests_resources"

--- a/travis/route.sh
+++ b/travis/route.sh
@@ -43,11 +43,6 @@ check_docker_dependency(){
     fi
 }
 
-remove_data_files(){
-    cd ${__DIR__} && \
-    rm -rf ../travis/data
-}
-
 start_docker_containers(){
     remove_docker_containers
     cd ${__DIR__} && \
@@ -76,7 +71,6 @@ run_tests_in_docker(){
 
 remove_tests_resources(){
     remove_docker_containers
-    remove_data_files
 }
 
 check_docker_dependency


### PR DESCRIPTION
The github runners do not rely on data mount binds anymore. All test data is temporary. So let's simplify the logic here.