### PR TITLE
Add pgsql status and reset commands to client

### DIFF
--- a/ext-src/swoole_postgres_coro.cc
+++ b/ext-src/swoole_postgres_coro.cc
@@ -1608,12 +1608,17 @@ static PHP_METHOD(swoole_postgresql_coro, escapeIdentifier) {
 static PHP_METHOD(swoole_postgresql_coro, status) {
     PGconn *pgsql;
     ConnStatusType status;
+    PGresult *pgsql_result;
 
     PGObject *object = php_swoole_postgresql_coro_get_object(ZEND_THIS);
     if (!object || !object->conn) {
         RETURN_FALSE;
     }
     pgsql = object->conn;
+
+    while ((pgsql_result = PQgetResult(pgsql))) {
+        PQclear(pgsql_result);
+    }
 
     status = PQstatus(pgsql);
 

--- a/ext-src/swoole_postgres_coro.cc
+++ b/ext-src/swoole_postgres_coro.cc
@@ -1607,6 +1607,7 @@ static PHP_METHOD(swoole_postgresql_coro, escapeIdentifier) {
 // connection status
 static PHP_METHOD(swoole_postgresql_coro, status) {
     PGconn *pgsql;
+    ConnStatusType status;
 
     PGObject *object = php_swoole_postgresql_coro_get_object(ZEND_THIS);
     if (!object || !object->conn) {
@@ -1614,7 +1615,7 @@ static PHP_METHOD(swoole_postgresql_coro, status) {
     }
     pgsql = object->conn;
 
-    ConnStatusType status = PQstatus(pgsql);
+    status = PQstatus(pgsql);
 
     RETVAL_LONG(ConnStatusType(status));
 }

--- a/tests/swoole_postgres_coro/query.phpt
+++ b/tests/swoole_postgres_coro/query.phpt
@@ -17,12 +17,16 @@ Co\run(function() {
     Assert::false($pg->prepare('', ''));
     Assert::false($pg->execute('', []));
     Assert::false($pg->metaData(''));
+    Assert::false($pg->status());
+    Assert::false($pg->reset());
 
     $conn = $pg->connect(PG_CONN);
     Assert::assert($conn);
     Assert::same((string)$pg->error, '');
     $result = $pg->escape("' or 1=1 & 2");
     Assert::same($result, "'' or 1=1 & 2");
+    $status = $pg->status();
+    Assert::same($status, OPENSWOOLE_PGRES_CONNECTION_OK);
 
     //
 
@@ -49,6 +53,15 @@ Co\run(function() {
         var_dump($retval, $pg->error, $pg->notices);
     }
 
+    $retval = $pg->query('SELECT * FROM weather');
+
+    if (!$retval) {
+        var_dump($retval, $pg->error, $pg->notices);
+    }
+
+    $empty = $pg->fetchAll($retval);
+    Assert::same($empty, []);
+
     $retval = $pg->query("INSERT INTO weather(city, temp_lo, temp_hi, prcp, date) VALUES ('San Francisco', 46, 50, 0.25, '1994-11-27') RETURNING id;");
     if (!$retval) {
         var_dump($retval, $pg->error, $pg->notices);
@@ -61,6 +74,18 @@ Co\run(function() {
     $arr = $pg->fetchAll($result);
 
     Assert::same($arr[0]['city'], 'San Francisco');
+
+    $reset = $pg->reset();
+    Assert::true($reset);
+    $status = $pg->status();
+    Assert::same($status, OPENSWOOLE_PGRES_CONNECTION_OK);
+
+    $result = $pg->query('SELECT 11, 22');
+    $arr = $pg->fetchAll($result);
+
+    Assert::same($arr[0]['?column?'], 11);
+    Assert::same($arr[0]['?column?1'], 22);
+
 });
 ?>
 --EXPECT--


### PR DESCRIPTION
This PR adds libpq PQstatus and PQreset functions to the PostgreSQL client.

This is mainly to assist long-lived connections to a database within a connection pool, where a connection may be dropped while the connection is still in the pool due to network or database resets.