### PR TITLE
Build fix for gcc < 4.9

### DIFF
--- a/ext-src/swoole_server.cc
+++ b/ext-src/swoole_server.cc
@@ -2743,7 +2743,7 @@ static zval vm_object_top() {
     }
 
     std::vector<std::pair<std::string,int>> vClasses (classes.begin(),classes.end());
-    std::sort(vClasses.begin(),vClasses.end(), [](std::pair<std::string,int>&a, std::pair<std::string,int>&b){
+    std::sort(vClasses.begin(),vClasses.end(), [](std::pair<std::string,int> const&a, std::pair<std::string,int> const&b){
        return a.second>b.second;
     });
 


### PR DESCRIPTION
gcc < 4.9 (as used in eg RHEL7) passes const temporaries to the comparitor contrary to 25.1/9, causing the build to error. Simple fix without side effects - declare arguments const.