### PR TITLE
properly define function aliasses

### DIFF
--- a/ext-src/swoole_event.cc
+++ b/ext-src/swoole_event.cc
@@ -77,22 +77,28 @@ static const zend_function_entry swoole_event_methods[] =
     ZEND_FENTRY(exit, ZEND_FN(swoole_event_exit), arginfo_class_Swoole_Event_exit, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_FE_END
 };
+
+static const zend_function_entry swoole_event_funcs[] =
+{
+    ZEND_FENTRY(swoole_event_add, ZEND_FN(swoole_event_add), arginfo_class_Swoole_Event_add, 0)
+    ZEND_FENTRY(swoole_event_del, ZEND_FN(swoole_event_del), arginfo_class_Swoole_Event_del, 0)
+    ZEND_FENTRY(swoole_event_set, ZEND_FN(swoole_event_set), arginfo_class_Swoole_Event_set, 0)
+    ZEND_FENTRY(swoole_event_isset, ZEND_FN(swoole_event_isset), arginfo_class_Swoole_Event_isset, 0)
+    ZEND_FENTRY(swoole_event_dispatch, ZEND_FN(swoole_event_dispatch), arginfo_class_Swoole_Event_dispatch, 0)
+    ZEND_FENTRY(swoole_event_defer, ZEND_FN(swoole_event_defer), arginfo_class_Swoole_Event_defer, 0)
+    ZEND_FENTRY(swoole_event_cycle, ZEND_FN(swoole_event_cycle), arginfo_class_Swoole_Event_cycle, 0)
+    ZEND_FENTRY(swoole_event_write, ZEND_FN(swoole_event_write), arginfo_class_Swoole_Event_write, 0)
+    ZEND_FENTRY(swoole_event_wait, ZEND_FN(swoole_event_wait), arginfo_class_Swoole_Event_wait, 0)
+    ZEND_FENTRY(swoole_event_exit, ZEND_FN(swoole_event_exit), arginfo_class_Swoole_Event_exit, 0)
+    PHP_FE_END
+};
 // clang-format on
 
 void php_swoole_event_minit(int module_number) {
     SW_INIT_CLASS_ENTRY(swoole_event, "Swoole\\Event", "swoole_event", nullptr, swoole_event_methods);
     SW_SET_CLASS_CREATE(swoole_event, sw_zend_create_object_deny);
 
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "add", CG(function_table), "swoole_event_add");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "del", CG(function_table), "swoole_event_del");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "set", CG(function_table), "swoole_event_set");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "isset", CG(function_table), "swoole_event_isset");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "dispatch", CG(function_table), "swoole_event_dispatch");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "defer", CG(function_table), "swoole_event_defer");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "cycle", CG(function_table), "swoole_event_cycle");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "write", CG(function_table), "swoole_event_write");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "wait", CG(function_table), "swoole_event_wait");
-    SW_FUNCTION_ALIAS(&swoole_event_ce->function_table, "exit", CG(function_table), "swoole_event_exit");
+    zend_register_functions(NULL, swoole_event_funcs, NULL, MODULE_PERSISTENT);
 }
 
 static void event_object_free(void *data) {

--- a/ext-src/swoole_timer.cc
+++ b/ext-src/swoole_timer.cc
@@ -62,6 +62,20 @@ static const zend_function_entry swoole_timer_methods[] =
     ZEND_FENTRY(clearAll, ZEND_FN(swoole_timer_clear_all), arginfo_class_Swoole_Timer_clearAll, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_FE_END
 };
+
+static const zend_function_entry swoole_timer_funcs[] =
+{
+    ZEND_FENTRY(swoole_timer_set, ZEND_FN(swoole_timer_set), arginfo_class_Swoole_Timer_set, ZEND_ACC_DEPRECATED)
+    ZEND_FENTRY(swoole_timer_after, ZEND_FN(swoole_timer_after), arginfo_class_Swoole_Timer_after, 0)
+    ZEND_FENTRY(swoole_timer_tick, ZEND_FN(swoole_timer_tick), arginfo_class_Swoole_Timer_tick, 0)
+    ZEND_FENTRY(swoole_timer_exists, ZEND_FN(swoole_timer_exists), arginfo_class_Swoole_Timer_exists, 0)
+    ZEND_FENTRY(swoole_timer_info, ZEND_FN(swoole_timer_info), arginfo_class_Swoole_Timer_info, 0)
+    ZEND_FENTRY(swoole_timer_stats, ZEND_FN(swoole_timer_stats), arginfo_class_Swoole_Timer_stats, 0)
+    ZEND_FENTRY(swoole_timer_list, ZEND_FN(swoole_timer_list), arginfo_class_Swoole_Timer_list, 0)
+    ZEND_FENTRY(swoole_timer_clear, ZEND_FN(swoole_timer_clear), arginfo_class_Swoole_Timer_clear, 0)
+    ZEND_FENTRY(swoole_timer_clear_all, ZEND_FN(swoole_timer_clear_all), arginfo_class_Swoole_Timer_clearAll, 0)
+    PHP_FE_END
+};
 // clang-format on
 
 void php_swoole_timer_minit(int module_number) {
@@ -75,15 +89,7 @@ void php_swoole_timer_minit(int module_number) {
                              nullptr,
                              spl_ce_ArrayIterator);
 
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "set", CG(function_table), "swoole_timer_set");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "after", CG(function_table), "swoole_timer_after");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "tick", CG(function_table), "swoole_timer_tick");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "exists", CG(function_table), "swoole_timer_exists");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "info", CG(function_table), "swoole_timer_info");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "stats", CG(function_table), "swoole_timer_stats");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "list", CG(function_table), "swoole_timer_list");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "clear", CG(function_table), "swoole_timer_clear");
-    SW_FUNCTION_ALIAS(&swoole_timer_ce->function_table, "clearAll", CG(function_table), "swoole_timer_clear_all");
+    zend_register_functions(NULL, swoole_timer_funcs, NULL, MODULE_PERSISTENT);
 
     SW_REGISTER_LONG_CONSTANT("SWOOLE_TIMER_MIN_MS", SW_TIMER_MIN_MS);
     SW_REGISTER_DOUBLE_CONSTANT("SWOOLE_TIMER_MIN_SEC", SW_TIMER_MIN_SEC);


### PR DESCRIPTION
Digging in extension reflection, I notice:

```
    Method [ <internal:openswoole> public method swoole_timer_list ] {

      - Parameters [0] {
      }
      - Return [ <D9>' ]

```

1/ this is obviously not a method
2/ return type is corrupted

Looking is code, it seems SW_FUNCTION_ALIAS does wrong things.

This PR drop most usage and use standard API call.

NOTICE: some usages are still there, perhaps have to be cleaned later.
