### PR TITLE
Implement draft statements object & LOB

### DIFF
--- a/ext-src/swoole_postgresql_coro.stub.php
+++ b/ext-src/swoole_postgresql_coro.stub.php
@@ -1,0 +1,32 @@
+<?php
+namespace Swoole\Coroutine {
+    class PostgreSQL {
+        public function __construct() {}
+        public function __destruct() {}
+        public function connect(string $conninfo, float $timeout = 2): bool {}
+        public function escape(string $string): false|string {}
+        public function escapeLiteral(string $string): false|string {}
+        public function escapeIdentifier(string $string): false|string {}
+        public function query(string $query): false|PostgreSQLStatement {}
+        public function prepare(string $query): false|PostgreSQLStatement {}
+        public function metaData(string $table_name): false|array {}
+        public function createLOB(): int|false {}
+        /** @return resource|false */
+        public function openLOB(int $oid, string $mode = "rb") {}
+        public function unlinkLOB(int $oid): bool {}
+        public function status(): int|false {}
+        public function reset(float $timeout = 0): bool {}
+    }
+
+    class PostgreSQLStatement {
+        public function execute(array $params = []): bool {}
+        public function fetchAll(int $result_type = SW_PGSQL_ASSOC): false|array {}
+        public function affectedRows(): false|int {}
+        public function numRows(): false|int {}
+        public function fieldCount(): false|int {}
+        public function fetchObject(int $row = null, ?string $class_name = null, array $ctor_params = []): false|object {}
+        public function fetchAssoc(int $row = null): false|array {}
+        public function fetchArray(int $row = null, int $result_type = OPENSWOOLE_PGSQL_BOTH): false|array {}
+        public function fetchRow(int $row = null, int $result_type = OPENSWOOLE_PGSQL_NUM): false|array {}
+    }
+}

--- a/ext-src/swoole_postgresql_coro_arginfo.h
+++ b/ext-src/swoole_postgresql_coro_arginfo.h
@@ -1,0 +1,83 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 206a8cca7282a53dc286a01e2d2ac5b2a0e5e5e3 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL___construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL___destruct arginfo_class_Swoole_Coroutine_PostgreSQL___construct
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_connect, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, conninfo, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "2")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_escape, 0, 1, MAY_BE_FALSE|MAY_BE_STRING)
+	ZEND_ARG_TYPE_INFO(0, string, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_escapeLiteral arginfo_class_Swoole_Coroutine_PostgreSQL_escape
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_escapeIdentifier arginfo_class_Swoole_Coroutine_PostgreSQL_escape
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_query, 0, 1, Swoole\\Coroutine\\PostgreSQLStatement, MAY_BE_FALSE)
+	ZEND_ARG_TYPE_INFO(0, query, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_prepare arginfo_class_Swoole_Coroutine_PostgreSQL_query
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_metaData, 0, 1, MAY_BE_FALSE|MAY_BE_ARRAY)
+	ZEND_ARG_TYPE_INFO(0, table_name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_createLOB, 0, 0, MAY_BE_LONG|MAY_BE_FALSE)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_openLOB, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, oid, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, mode, IS_STRING, 0, "\"rb\"")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_unlinkLOB, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, oid, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_status arginfo_class_Swoole_Coroutine_PostgreSQL_createLOB
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_reset, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, timeout, IS_DOUBLE, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_execute, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, params, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchAll, 0, 0, MAY_BE_FALSE|MAY_BE_ARRAY)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "SW_PGSQL_ASSOC")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_affectedRows, 0, 0, MAY_BE_FALSE|MAY_BE_LONG)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQLStatement_numRows arginfo_class_Swoole_Coroutine_PostgreSQLStatement_affectedRows
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fieldCount arginfo_class_Swoole_Coroutine_PostgreSQLStatement_affectedRows
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchObject, 0, 0, MAY_BE_FALSE|MAY_BE_OBJECT)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, class_name, IS_STRING, 1, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, ctor_params, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchAssoc, 0, 0, MAY_BE_FALSE|MAY_BE_ARRAY)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 0, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchArray, 0, 0, MAY_BE_FALSE|MAY_BE_ARRAY)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "OPENSWOOLE_PGSQL_BOTH")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchRow, 0, 0, MAY_BE_FALSE|MAY_BE_ARRAY)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, row, IS_LONG, 0, "null")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, result_type, IS_LONG, 0, "OPENSWOOLE_PGSQL_NUM")
+ZEND_END_ARG_INFO()

--- a/ext-src/swoole_postgresql_coro_legacy_arginfo.h
+++ b/ext-src/swoole_postgresql_coro_legacy_arginfo.h
@@ -1,0 +1,78 @@
+/* This is a generated file, edit the .stub.php file instead.
+ * Stub hash: 206a8cca7282a53dc286a01e2d2ac5b2a0e5e5e3 */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL___construct, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL___destruct arginfo_class_Swoole_Coroutine_PostgreSQL___construct
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_connect, 0, 0, 1)
+	ZEND_ARG_INFO(0, conninfo)
+	ZEND_ARG_INFO(0, timeout)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_escape, 0, 0, 1)
+	ZEND_ARG_INFO(0, string)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_escapeLiteral arginfo_class_Swoole_Coroutine_PostgreSQL_escape
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_escapeIdentifier arginfo_class_Swoole_Coroutine_PostgreSQL_escape
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_query, 0, 0, 1)
+	ZEND_ARG_INFO(0, query)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_prepare arginfo_class_Swoole_Coroutine_PostgreSQL_query
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_metaData, 0, 0, 1)
+	ZEND_ARG_INFO(0, table_name)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_createLOB arginfo_class_Swoole_Coroutine_PostgreSQL___construct
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_openLOB, 0, 0, 1)
+	ZEND_ARG_INFO(0, oid)
+	ZEND_ARG_INFO(0, mode)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_unlinkLOB, 0, 0, 1)
+	ZEND_ARG_INFO(0, oid)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQL_status arginfo_class_Swoole_Coroutine_PostgreSQL___construct
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQL_reset, 0, 0, 0)
+	ZEND_ARG_INFO(0, timeout)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_execute, 0, 0, 0)
+	ZEND_ARG_INFO(0, params)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchAll, 0, 0, 0)
+	ZEND_ARG_INFO(0, result_type)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQLStatement_affectedRows arginfo_class_Swoole_Coroutine_PostgreSQL___construct
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQLStatement_numRows arginfo_class_Swoole_Coroutine_PostgreSQL___construct
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fieldCount arginfo_class_Swoole_Coroutine_PostgreSQL___construct
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchObject, 0, 0, 0)
+	ZEND_ARG_INFO(0, row)
+	ZEND_ARG_INFO(0, class_name)
+	ZEND_ARG_INFO(0, ctor_params)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchAssoc, 0, 0, 0)
+	ZEND_ARG_INFO(0, row)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchArray, 0, 0, 0)
+	ZEND_ARG_INFO(0, row)
+	ZEND_ARG_INFO(0, result_type)
+ZEND_END_ARG_INFO()
+
+#define arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchRow arginfo_class_Swoole_Coroutine_PostgreSQLStatement_fetchArray

--- a/tests/swoole_postgres_coro/issue227.phpt
+++ b/tests/swoole_postgres_coro/issue227.phpt
@@ -24,20 +24,18 @@ co::run(function() {
     $retval = $pg->query("INSERT INTO weather(city, temp_lo, temp_hi, prcp, date) VALUES ('New York', 35, 45, 0.5, '1994-11-27') RETURNING id;");
 
     go(function() use ($pg) {
-      $pg->prepare('selectOne', 'SELECT * FROM weather');
-      $result1 = $pg->execute('selectOne', []);
-      $row1 = $pg->fetchAssoc($result1);
+      $selectOne = $pg->prepare('SELECT * FROM weather');
+      $result1 = $selectOne->execute([]);
+      $row1 = $selectOne->fetchAssoc();
       var_dump($row1);
       co::sleep(2);
-      $row2 = $pg->fetchAssoc($result1);
+      $row2 = $selectOne->fetchAssoc();
       var_dump($row2);
     });
 
     go(function() use ($pg) {
       co::sleep(1);
-      $result2 = $pg->query('SELECT 1');
-      $row3 = $pg->fetchAssoc($result2);
-      var_dump($row3);
+      $selectSecond = $pg->query('SELECT 1');
     });
 });
 ?>
@@ -55,10 +53,6 @@ array(6) {
   float(0.25)
   ["date"]=>
   string(10) "1994-11-27"
-}
-array(1) {
-  ["?column?"]=>
-  int(1)
 }
 array(6) {
   ["id"]=>

--- a/tests/swoole_postgres_coro/query.phpt
+++ b/tests/swoole_postgres_coro/query.phpt
@@ -15,7 +15,7 @@ co::run(function() {
     Assert::false($pg->escapeIdentifier(''));
     Assert::false($pg->query(''));
     Assert::false($pg->prepare('', ''));
-    Assert::false($pg->execute('', []));
+    //Assert::false($pg->execute('', []));
     Assert::false($pg->metaData(''));
     Assert::false($pg->status());
     Assert::false($pg->reset());
@@ -31,7 +31,7 @@ co::run(function() {
     //
 
     $result = $pg->query('SELECT 11, 22');
-    $arr = $pg->fetchAll($result);
+    $arr = $result->fetchAll();
 
     Assert::same($arr[0]['?column?'], 11);
     Assert::same($arr[0]['?column?1'], 22);
@@ -59,7 +59,7 @@ co::run(function() {
         var_dump($retval, $pg->error, $pg->notices);
     }
 
-    $empty = $pg->fetchAll($retval);
+    $empty = $retval->fetchAll();
     Assert::same($empty, []);
 
     $retval = $pg->query("INSERT INTO weather(city, temp_lo, temp_hi, prcp, date) VALUES ('San Francisco', 46, 50, 0.25, '1994-11-27') RETURNING id;");
@@ -67,11 +67,11 @@ co::run(function() {
         var_dump($retval, $pg->error, $pg->notices);
     }
 
-    $rows = $pg->numRows($retval);
+    $rows = $retval->numRows();
     Assert::same($rows, 1);
 
     $result = $pg->query('SELECT * FROM weather;');
-    $arr = $pg->fetchAll($result);
+    $arr = $result->fetchAll();
 
     Assert::same($arr[0]['city'], 'San Francisco');
 
@@ -81,7 +81,7 @@ co::run(function() {
     Assert::same($status, OPENSWOOLE_PG_CONNECTION_OK);
 
     $result = $pg->query('SELECT 11, 22');
-    $arr = $pg->fetchAll($result);
+    $arr = $result->fetchAll();
 
     Assert::same($arr[0]['?column?'], 11);
     Assert::same($arr[0]['?column?1'], 22);

--- a/tests/swoole_postgres_coro/query.phpt
+++ b/tests/swoole_postgres_coro/query.phpt
@@ -14,8 +14,8 @@ co::run(function() {
     Assert::false($pg->escapeLiteral(''));
     Assert::false($pg->escapeIdentifier(''));
     Assert::false($pg->query(''));
-    Assert::false($pg->prepare('', ''));
-    //Assert::false($pg->execute('', []));
+    Assert::false($pg->prepare(''));
+    //Assert::false($pg->execute([]));
     Assert::false($pg->metaData(''));
     Assert::false($pg->status());
     Assert::false($pg->reset());


### PR DESCRIPTION
Initially it should be fix for #227  
But it is impossible save current row state of result shared in PGObject. This should be on the result level, but result in current implementation just zend resource. So anyway should implement some structure and why it shouldn't be Statement (like PDOStatement class) and then I ported Statements implementation from another Swoole v5.0.
Now important question - what do it with backward incompatibility? 

1. Just changes signature (like now) and release new major version
2. Backward incompatibility way but more mainten code: leave OpenSwoole\Coroutine\Postgresql class as is and deprecated it copy and move statement functional into new classes OpenSwoole\Coroutine\Postgresql\Connection + OpenSwoole\Coroutine\Postgresql\Statement
3. Something else?

Anyway problem in #227 was resolving (look tests) because moving row fetch counter into statement object. 