### PR TITLE
docs: add `sudo` privileges to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cd ext-openswoole
 git checkout v26.2.0
 phpize && \
 ./configure && \
-make && make install
+make && sudo make install
 ```
 
 You can find how to fix [Common Installation Errors](https://openswoole.com/docs/get-started/common-install-errors) if there are errors in the installation.


### PR DESCRIPTION
Add `sudo` to the build example (`make install` step) in the documentation.

The docs recommend using `sudo` privileges. This change also keeps the instructions consistent with other sections of the `Markdown` documentation where `sudo` is already specified for the installation step.