### PR TITLE
fix: enable iouring for alpine linux

### DIFF
--- a/include/openswoole_io_uring.h
+++ b/include/openswoole_io_uring.h
@@ -19,7 +19,9 @@
 #ifdef HAVE_IO_URING
 #include <liburing.h>
 #include <sys/stat.h>
+#ifndef __MUSL__
 #include <linux/stat.h>
+#endif
 
 namespace openswoole {
 

--- a/include/openswoole_io_uring.h
+++ b/include/openswoole_io_uring.h
@@ -19,7 +19,7 @@
 #ifdef HAVE_IO_URING
 #include <liburing.h>
 #include <sys/stat.h>
-#ifndef __MUSL__
+#if defined(__linux__) && defined(__GLIBC__)
 #include <linux/stat.h>
 #endif
 

--- a/tests/include/lib/composer.json
+++ b/tests/include/lib/composer.json
@@ -7,7 +7,7 @@
     }
   },
   "require": {
-    "guzzlehttp/guzzle": "7.9.2",
+    "guzzlehttp/guzzle": "7.15.3",
     "guzzlehttp/promises": "^2.0",
     "guzzlehttp/psr7": "^2.7",
     "php-http/async-client-implementation": "^1.0",


### PR DESCRIPTION
iouring doesn't currently work under alpine linux distros.